### PR TITLE
corrected IE9 rewrite rule so that it doesn't break site deployed to …

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -284,7 +284,7 @@ AddDefaultCharset utf-8
     RewriteCond %{REQUEST_URI} !^(/index\.php|/img|/js|/css|/robots\.txt|/favicon\.ico)
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule (.*) /#/$1 [NE,R,L]
+    RewriteRule (.*) #/$1 [NE,R,L]
 </IfModule>
 
 # ##############################################################################

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ It is best to test SC-app-* modules from within an app as you develop it. Theref
 2. Create a new branch in your module's repository and push it up to GitHub.
 3. In the base directory of an app that you can use for testing the module's development, run the following:
 
-    bower install --save Southbank-Centre/<SC-app-module-name>#<branch-name>
+		bower install --save Southbank-Centre/<SC-app-module-name>#<branch-name>
 
 4. Make changes to the module. Make sure to always run `grunt build` after making changes.
 5. Commit your changes to your branch and push the changes up to GitHub.


### PR DESCRIPTION
…a sub-path

This pul requests means that the IE9 rewrite workaround doesn't rewrite relative to the root anymore.

Old: southbankcentre.org/style-guide/1 => southbankcentre.org/#/1

New: southbankcentre.org/style-guide/1 => southbankcentre.org/style-guide/#/1